### PR TITLE
Update timers to have an initial delay and repeat count.

### DIFF
--- a/include/Server/Components/Timers/timers.hpp
+++ b/include/Server/Components/Timers/timers.hpp
@@ -12,11 +12,15 @@ struct ITimer {
     /// Get the remaining time until time out
     virtual Milliseconds remaining() const = 0;
 
-    /// Get whether the timer is repeating
-    virtual bool repeating() const = 0;
+    /// Get how many calls there are left.
+    virtual unsigned int calls() const = 0;
 
     /// Get the timer's interval
     virtual Milliseconds interval() const = 0;
+	
+    /// Mark the timer as being called now.  Returns `true` when there are more
+	/// calls to make after this one.
+    virtual bool trigger() = 0;
 
     /// Immediately kill the timer
     virtual void kill() = 0;
@@ -42,4 +46,12 @@ struct ITimersComponent : public IComponent {
     /// @param interval The time after which the timer will time out
     /// @param repeating Whether the timer repeats when it times out
     virtual ITimer* create(TimerTimeOutHandler* handler, Milliseconds interval, bool repeating) = 0;
+
+    /// Create a new timer handled by a handler which times out after a certain time
+    /// @param handler The handler which handlers time out.
+    /// @param initial The time before the first trigger.
+    /// @param interval The time after which the timer will time out.
+    /// @param count The number of times to call the timer, 0 = infinite.
+    virtual ITimer* create(TimerTimeOutHandler* handler, Milliseconds initial, Milliseconds interval, unsigned int count) = 0;
 };
+


### PR DESCRIPTION
One of the blog posts actually documented this feature, yet it has vanished.