### PR TITLE
Rename project to OMP-SDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.19)
-project(SDK LANGUAGES C CXX VERSION 0.0.1)
+project(OMP-SDK LANGUAGES C CXX VERSION 0.0.1)
 
 if (NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)
 	message(
@@ -18,32 +18,32 @@ conan_omp_add_lib(robin-hood-hashing 3.11.5)
 conan_omp_add_lib(span-lite 0.10.3)
 conan_omp_add_lib(string-view-lite 1.6.0)
 
-add_library(SDK INTERFACE)
+add_library(OMP-SDK INTERFACE)
 
 if(MSVC)
-	target_compile_options(SDK INTERFACE
+	target_compile_options(OMP-SDK INTERFACE
 		"/fp:strict"
 		"/arch:SSE2"
 	)
 elseif(UNIX)
-	target_compile_options(SDK INTERFACE
+	target_compile_options(OMP-SDK INTERFACE
 		-msse2
 		-mfpmath=sse
 	)
 endif()
 
-target_compile_options(SDK INTERFACE
+target_compile_options(OMP-SDK INTERFACE
 	-Werror=format
 )
 
-target_link_libraries(SDK INTERFACE
+target_link_libraries(OMP-SDK INTERFACE
 	CONAN_PKG::glm
 	CONAN_PKG::robin-hood-hashing
 	CONAN_PKG::span-lite
 	CONAN_PKG::string-view-lite
 )
 
-target_compile_definitions(SDK INTERFACE
+target_compile_definitions(OMP-SDK INTERFACE
 	GLM_FORCE_SSE2
 	GLM_FORCE_QUAT_DATA_WXYZ
 	NOMINMAX
@@ -51,8 +51,8 @@ target_compile_definitions(SDK INTERFACE
 	span_CONFIG_SELECT_SPAN=span_SPAN_NONSTD
 )
 
-target_include_directories(SDK INTERFACE include/)
+target_include_directories(OMP-SDK INTERFACE include/)
 
-file(GLOB_RECURSE sdk_source_list "*.hpp")
+file(GLOB_RECURSE omp_sdk_source_list "*.hpp")
 
-set_property(TARGET SDK PROPERTY SOURCES ${sdk_source_list})
+set_property(TARGET OMP-SDK PROPERTY SOURCES ${omp_sdk_source_list})


### PR DESCRIPTION
Renaming cmake generated project to OMP-SDK instead of SDK, to avoid conflicts with other projects