### PR TITLE
Tweaks for consistency - Objects.

### DIFF
--- a/include/Server/Components/Objects/objects.hpp
+++ b/include/Server/Components/Objects/objects.hpp
@@ -5,6 +5,24 @@
 struct IVehicle;
 
 /// Object material text align values
+enum ObjectMaterialSize {
+	ObjectMaterialSize_32x32 = 10,
+	ObjectMaterialSize_64x32 = 20,
+	ObjectMaterialSize_64x64 = 30,
+	ObjectMaterialSize_128x32 = 40,
+	ObjectMaterialSize_128x64 = 50,
+	ObjectMaterialSize_128x128 = 60,
+	ObjectMaterialSize_256x32 = 70,
+	ObjectMaterialSize_256x64 = 80,
+	ObjectMaterialSize_256x128 = 90,
+	ObjectMaterialSize_256x256 = 100,
+	ObjectMaterialSize_512x64 = 110,
+	ObjectMaterialSize_512x128 = 120,
+	ObjectMaterialSize_512x256 = 130,
+	ObjectMaterialSize_512x512 = 140
+};
+
+/// Object material text align values
 enum ObjectMaterialTextAlign {
     ObjectMaterialTextAlign_Left,
     ObjectMaterialTextAlign_Center,
@@ -140,13 +158,13 @@ struct IBaseObject : public IExtensible, public IEntity {
     virtual bool getCameraCollision() const = 0;
 
     /// Start moving the object
-    virtual void startMoving(const ObjectMoveData& data) = 0;
+    virtual void move(const ObjectMoveData& data) = 0;
 
     /// Get whether the object is moving
     virtual bool isMoving() const = 0;
 
     /// Stop moving the object prematurely
-    virtual void stopMoving() = 0;
+    virtual void stop() = 0;
 
     /// Get object moving data
     virtual const ObjectMoveData& getMovingData() const = 0;
@@ -161,13 +179,13 @@ struct IBaseObject : public IExtensible, public IEntity {
     virtual const ObjectAttachmentData& getAttachmentData() const = 0;
 
     /// Get the object's material data
-    virtual bool getMaterialData(uint32_t index, const ObjectMaterialData*& out) const = 0;
+    virtual bool getMaterialData(uint32_t materialIndex, const ObjectMaterialData*& out) const = 0;
 
     /// Set the object's material to a texture
-    virtual void setMaterial(uint32_t index, int model, StringView txd, StringView texture, Colour colour) = 0;
+    virtual void setMaterial(uint32_t materialIndex, int model, StringView textureLibrary, StringView textureName, Colour colour) = 0;
 
     /// Set the object's material to some text
-    virtual void setMaterialText(uint32_t index, StringView text, int mtlSize, StringView fontFace, int fontSize, bool bold, Colour fontColour, Colour backColour, ObjectMaterialTextAlign align) = 0;
+    virtual void setMaterialText(uint32_t materialIndex, StringView text, ObjectMaterialSize materialSize, StringView fontFace, int fontSize, bool bold, Colour fontColour, Colour backgroundColour, ObjectMaterialTextAlign align) = 0;
 };
 
 /// An object interface
@@ -236,19 +254,19 @@ struct IPlayerObjectData : public IExtension, public IPool<IPlayerObject> {
     virtual const ObjectAttachmentSlotData& getAttachedObject(int index) const = 0;
 
     /// Initiate object selection for the player
-    virtual void beginObjectSelection() = 0;
+    virtual void beginSelecting() = 0;
 
     /// Get whether the player is selecting objects
     virtual bool selectingObject() const = 0;
 
     /// End selection and editing objects for the player
-    virtual void endObjectEdit() = 0;
+    virtual void endEditing() = 0;
 
     /// Edit the object for the player
-    virtual void editObject(IObject& object) = 0;
+    virtual void beginEditing(IObject& object) = 0;
 
     /// Edit the player object for the player
-    virtual void editObject(IPlayerObject& object) = 0;
+    virtual void beginEditing(IPlayerObject& object) = 0;
 
     /// Check if the player is editing an object
     virtual bool editingObject() const = 0;


### PR DESCRIPTION
This is basically to try and stop the SDK being confusing and legacy in the first version.  Some functions use `Color`, some use `Colour`; some functions take multiple parameters, some functions take a single `struct`; some events use `Player`, some don't; and there are other minor improvements that can be made to massively improve intuition on functionality and map existing collective knowledge from the well known and extensively documented Pawn SDK to the new SDK to help adoption.

* Rename parameters for consistency:
    Everything is `camelCase` now, with no Hungarian notation.

* Rename parameters for clarity:
    While we might know what `txd` or `caption` mean, `textureLibrary` and `title` are much clearer without context.

* Rename a few functions slightly:
    As a general rule Pawn functions of the form `VerbLibraryNoun` (for example `GetObjectPos`) become `Library::verbNoun` (for example `Object::getPos`) in the SDK.  This isn't applied completely everywhere, but keeping the two somewhat in sync allows for much smoother transitions and use of existing documentation.  Some really can't be mapped 1:1, such as a method returning an entire structure and a Pawn function that only returns one field of that struct.  Additionally, `Pos` is always expanded to `Position`.  In a few rare cases the SDK names are clearer and more consistent than the original Pawn names (not hard, they weren't that consistent to begin with), in those cases new natives have been added to reflect the new names (this is not full `Object@Create` syntax yet).

* Remove `id`:
    `id` on many parameters is superfluous, so I'm trying to reserve it only for IDs of externally exposed entities.  For example `vehicleid` - yes, `modelid` - no.  The former is an assigned UID, the latter is essentially a constant.

* Expand parameters:
    Unless there's a very good reason otherwise SDK functions should take the majority of their parameters as actual separate parameters, not a single parameter that is an object containing everything else.  If you have to construct a temporary object just to call a method that's not great developer UX.

* Unify event names:
    While they might not always be the *best* name, they are at least well known and understood names.