### PR TITLE
Tweaks for consistency - Actors.

### DIFF
--- a/include/Server/Components/Actors/actors.hpp
+++ b/include/Server/Components/Actors/actors.hpp
@@ -55,7 +55,7 @@ struct IActor : public IExtensible, public IEntity {
 };
 
 struct ActorEventHandler {
-    virtual void onPlayerDamageActor(IPlayer& player, IActor& actor, float amount, unsigned weapon, BodyPart part) { }
+    virtual void onPlayerGiveDamageActor(IPlayer& player, IActor& actor, float amount, unsigned weapon, BodyPart part) { }
     virtual void onActorStreamOut(IActor& actor, IPlayer& forPlayer) { }
     virtual void onActorStreamIn(IActor& actor, IPlayer& forPlayer) { }
 };


### PR DESCRIPTION
This is basically to try and stop the SDK being confusing and legacy in the first version.  Some functions use `Color`, some use `Colour`; some functions take multiple parameters, some functions take a single `struct`; some events use `Player`, some don't; and there are other minor improvements that can be made to massively improve intuition on functionality and map existing collective knowledge from the well known and extensively documented Pawn SDK to the new SDK to help adoption.

* Rename parameters for consistency:
    Everything is `camelCase` now, with no Hungarian notation.

* Rename parameters for clarity:
    While we might know what `txd` or `caption` mean, `textureLibrary` and `title` are much clearer without context.

* Rename a few functions slightly:
    As a general rule Pawn functions of the form `VerbLibraryNoun` (for example `GetObjectPos`) become `Library::verbNoun` (for example `Object::getPos`) in the SDK.  This isn't applied completely everywhere, but keeping the two somewhat in sync allows for much smoother transitions and use of existing documentation.  Some really can't be mapped 1:1, such as a method returning an entire structure and a Pawn function that only returns one field of that struct.  Additionally, `Pos` is always expanded to `Position`.  In a few rare cases the SDK names are clearer and more consistent than the original Pawn names (not hard, they weren't that consistent to begin with), in those cases new natives have been added to reflect the new names (this is not full `Object@Create` syntax yet).

* Remove `id`:
    `id` on many parameters is superfluous, so I'm trying to reserve it only for IDs of externally exposed entities.  For example `vehicleid` - yes, `modelid` - no.  The former is an assigned UID, the latter is essentially a constant.

* Expand parameters:
    Unless there's a very good reason otherwise SDK functions should take the majority of their parameters as actual separate parameters, not a single parameter that is an object containing everything else.  If you have to construct a temporary object just to call a method that's not great developer UX.

* Unify event names:
    While they might not always be the *best* name, they are at least well known and understood names.