### PR TITLE
Fix unbound access in getRandomVehicleColour for ids 610 and 611

### DIFF
--- a/include/Server/Components/Vehicles/vehicle_colours.hpp
+++ b/include/Server/Components/Vehicles/vehicle_colours.hpp
@@ -216,8 +216,8 @@ inline void getRandomVehicleColour(int modelid, int& colour1, int& colour2, int&
 		1156, // 607 - bagboxb
 		1156, // 608 - tugstair
 		1157, // 609 - boxburg
-		1158, // 610 - farmtr1
-		1158, // 611 - utiltr1
+		1157, // 610 - farmtr1
+		1157, // 611 - utiltr1
 		1158
 	};
 


### PR DESCRIPTION
vehiclePrimaryColours and vehicleSecondaryColours is 1158 long, last valid index is 1157, but vehicleIndex was 1158 for id 610 "farmtr1" and id 611 "utiltr1".

