### PR TITLE
Skip NEON -mfpu flag for Apple ARM devices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ elseif(UNIX)
 			-mfpmath=sse
 		)
 	else()
-		if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
+		if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm" AND NOT APPLE)
 			target_compile_options(OMP-SDK INTERFACE "-mfpu=neon")
 		endif()
 		if(TARGET_BUILD_ARCH)


### PR DESCRIPTION
**Why exclude Apple?**
- Apple Silicon (M1/M2/M3 chips) already has NEON enabled by default
- These chips use a different ARM variant (ARMv8-A/AArch64) where NEON is mandatory
- Adding this flag on Apple platforms could cause build issues or is simply unnecessary