### PR TITLE
Fix for Errors like error LNK2005: _amx_* already defined in *.obj

### DIFF
--- a/include/Server/Components/Pawn/Impl/pawn_impl.hpp
+++ b/include/Server/Components/Pawn/Impl/pawn_impl.hpp
@@ -9,7 +9,7 @@
 static IComponentList* components_;
 static PawnLookup lookups_;
 
-void setAmxLookups()
+inline void setAmxLookups()
 {
 	// Refresh the list.
 	if (components_)
@@ -36,13 +36,13 @@ void setAmxLookups()
 	}
 }
 
-void setAmxLookups(IComponentList* components)
+inline void setAmxLookups(IComponentList* components)
 {
 	components_ = components;
 	setAmxLookups();
 }
 
-void setAmxLookups(ICore* core)
+inline void setAmxLookups(ICore* core)
 {
 	lookups_.core = core;
 	lookups_.config = &core->getConfig();
@@ -50,7 +50,7 @@ void setAmxLookups(ICore* core)
 	setAmxLookups();
 }
 
-PawnLookup* getAmxLookups()
+inline PawnLookup* getAmxLookups()
 {
 	return &lookups_;
 }
@@ -58,12 +58,12 @@ PawnLookup* getAmxLookups()
 
 static std::array<void*, NUM_AMX_FUNCS> funcs_;
 
-void setAmxFunctions(std::array<void*, NUM_AMX_FUNCS> const& funcs)
+inline void setAmxFunctions(std::array<void*, NUM_AMX_FUNCS> const& funcs)
 {
 	funcs_ = funcs;
 }
 
-void setAmxFunctions()
+inline void setAmxFunctions()
 {
 	funcs_.fill(nullptr);
 }
@@ -199,234 +199,234 @@ typedef void (*amx_Swap32_t)(uint32_t* v);
 typedef void (*amx_Swap64_t)(uint64_t* v);
 #endif
 
-uint16_t* AMXAPI amx_Align16(uint16_t* v)
+inline uint16_t* AMXAPI amx_Align16(uint16_t* v)
 {
 	return ((amx_Align16_t)funcs_[AMX_FUNC_Align16])(v);
 }
 
-uint32_t* AMXAPI amx_Align32(uint32_t* v)
+inline uint32_t* AMXAPI amx_Align32(uint32_t* v)
 {
 	return ((amx_Align32_t)funcs_[AMX_FUNC_Align32])(v);
 }
 
 #if defined _I64_MAX || defined HAVE_I64
-uint64_t* AMXAPI amx_Align64(uint64_t* v)
+inline uint64_t* AMXAPI amx_Align64(uint64_t* v)
 {
 	return ((amx_Align64_t)funcs_[AMX_FUNC_Align64])(v);
 }
 #endif
 
-int AMXAPI amx_Allot(AMX* amx, int cells, cell* amx_addr, cell** phys_addr)
+inline int AMXAPI amx_Allot(AMX* amx, int cells, cell* amx_addr, cell** phys_addr)
 {
 	return ((amx_Allot_t)funcs_[AMX_FUNC_Allot])(amx, cells, amx_addr, phys_addr);
 }
 
-int AMXAPI amx_Callback(AMX* amx, cell index, cell* result, const cell* params)
+inline int AMXAPI amx_Callback(AMX* amx, cell index, cell* result, const cell* params)
 {
 	return ((amx_Callback_t)funcs_[AMX_FUNC_Callback])(amx, index, result, params);
 }
 
-int AMXAPI amx_Cleanup(AMX* amx)
+inline int AMXAPI amx_Cleanup(AMX* amx)
 {
 	return ((amx_Cleanup_t)funcs_[AMX_FUNC_Cleanup])(amx);
 }
 
-int AMXAPI amx_Clone(AMX* amxClone, AMX* amxSource, void* data)
+inline int AMXAPI amx_Clone(AMX* amxClone, AMX* amxSource, void* data)
 {
 	return ((amx_Clone_t)funcs_[AMX_FUNC_Clone])(amxClone, amxSource, data);
 }
 
-int AMXAPI amx_Exec(AMX* amx, cell* retval, int index)
+inline int AMXAPI amx_Exec(AMX* amx, cell* retval, int index)
 {
 	return ((amx_Exec_t)funcs_[AMX_FUNC_Exec])(amx, retval, index);
 }
 
-int AMXAPI amx_FindNative(AMX* amx, const char* name, int* index)
+inline int AMXAPI amx_FindNative(AMX* amx, const char* name, int* index)
 {
 	return ((amx_FindNative_t)funcs_[AMX_FUNC_FindNative])(amx, name, index);
 }
 
-int AMXAPI amx_FindPublic(AMX* amx, const char* funcname, int* index)
+inline int AMXAPI amx_FindPublic(AMX* amx, const char* funcname, int* index)
 {
 	return ((amx_FindPublic_t)funcs_[AMX_FUNC_FindPublic])(amx, funcname, index);
 }
 
-int AMXAPI amx_FindPubVar(AMX* amx, const char* varname, cell* amx_addr)
+inline int AMXAPI amx_FindPubVar(AMX* amx, const char* varname, cell* amx_addr)
 {
 	return ((amx_FindPubVar_t)funcs_[AMX_FUNC_FindPubVar])(amx, varname, amx_addr);
 }
 
-int AMXAPI amx_FindTagId(AMX* amx, cell tag_id, char* tagname)
+inline int AMXAPI amx_FindTagId(AMX* amx, cell tag_id, char* tagname)
 {
 	return ((amx_FindTagId_t)funcs_[AMX_FUNC_FindTagId])(amx, tag_id, tagname);
 }
 
-int AMXAPI amx_Flags(AMX* amx, uint16_t* flags)
+inline int AMXAPI amx_Flags(AMX* amx, uint16_t* flags)
 {
 	return ((amx_Flags_t)funcs_[AMX_FUNC_Flags])(amx, flags);
 }
 
-int AMXAPI amx_GetAddr(AMX* amx, cell amx_addr, cell** phys_addr)
+inline int AMXAPI amx_GetAddr(AMX* amx, cell amx_addr, cell** phys_addr)
 {
 	return ((amx_GetAddr_t)funcs_[AMX_FUNC_GetAddr])(amx, amx_addr, phys_addr);
 }
 
-int AMXAPI amx_GetNative(AMX* amx, int index, char* funcname)
+inline int AMXAPI amx_GetNative(AMX* amx, int index, char* funcname)
 {
 	return ((amx_GetNative_t)funcs_[AMX_FUNC_GetNative])(amx, index, funcname);
 }
 
-int AMXAPI amx_GetPublic(AMX* amx, int index, char* funcname)
+inline int AMXAPI amx_GetPublic(AMX* amx, int index, char* funcname)
 {
 	return ((amx_GetPublic_t)funcs_[AMX_FUNC_GetPublic])(amx, index, funcname);
 }
 
-int AMXAPI amx_GetPubVar(AMX* amx, int index, char* varname, cell* amx_addr)
+inline int AMXAPI amx_GetPubVar(AMX* amx, int index, char* varname, cell* amx_addr)
 {
 	return ((amx_GetPubVar_t)funcs_[AMX_FUNC_GetPubVar])(amx, index, varname, amx_addr);
 }
 
-int AMXAPI amx_GetString(char* dest, const cell* source, int use_wchar, size_t size)
+inline int AMXAPI amx_GetString(char* dest, const cell* source, int use_wchar, size_t size)
 {
 	return ((amx_GetString_t)funcs_[AMX_FUNC_GetString])(dest, source, use_wchar, size);
 }
 
-int AMXAPI amx_GetTag(AMX* amx, int index, char* tagname, cell* tag_id)
+inline int AMXAPI amx_GetTag(AMX* amx, int index, char* tagname, cell* tag_id)
 {
 	return ((amx_GetTag_t)funcs_[AMX_FUNC_GetTag])(amx, index, tagname, tag_id);
 }
 
-int AMXAPI amx_GetUserData(AMX* amx, long tag, void** ptr)
+inline int AMXAPI amx_GetUserData(AMX* amx, long tag, void** ptr)
 {
 	return ((amx_GetUserData_t)funcs_[AMX_FUNC_GetUserData])(amx, tag, ptr);
 }
 
-int AMXAPI amx_Init(AMX* amx, void* program)
+inline int AMXAPI amx_Init(AMX* amx, void* program)
 {
 	return ((amx_Init_t)funcs_[AMX_FUNC_Init])(amx, program);
 }
 
-int AMXAPI amx_InitJIT(AMX* amx, void* reloc_table, void* native_code)
+inline int AMXAPI amx_InitJIT(AMX* amx, void* reloc_table, void* native_code)
 {
 	return ((amx_InitJIT_t)funcs_[AMX_FUNC_InitJIT])(amx, reloc_table, native_code);
 }
 
-int AMXAPI amx_MemInfo(AMX* amx, long* codesize, long* datasize, long* stackheap)
+inline int AMXAPI amx_MemInfo(AMX* amx, long* codesize, long* datasize, long* stackheap)
 {
 	return ((amx_MemInfo_t)funcs_[AMX_FUNC_MemInfo])(amx, codesize, datasize, stackheap);
 }
 
-int AMXAPI amx_NameLength(AMX* amx, int* length)
+inline int AMXAPI amx_NameLength(AMX* amx, int* length)
 {
 	return ((amx_NameLength_t)funcs_[AMX_FUNC_NameLength])(amx, length);
 }
 
-AMX_NATIVE_INFO* AMXAPI amx_NativeInfo(const char* name, AMX_NATIVE func)
+inline AMX_NATIVE_INFO* AMXAPI amx_NativeInfo(const char* name, AMX_NATIVE func)
 {
 	return ((amx_NativeInfo_t)funcs_[AMX_FUNC_NativeInfo])(name, func);
 }
 
-int AMXAPI amx_NumNatives(AMX* amx, int* number)
+inline int AMXAPI amx_NumNatives(AMX* amx, int* number)
 {
 	return ((amx_NumNatives_t)funcs_[AMX_FUNC_NumNatives])(amx, number);
 }
 
-int AMXAPI amx_NumPublics(AMX* amx, int* number)
+inline int AMXAPI amx_NumPublics(AMX* amx, int* number)
 {
 	return ((amx_NumPublics_t)funcs_[AMX_FUNC_NumPublics])(amx, number);
 }
 
-int AMXAPI amx_NumPubVars(AMX* amx, int* number)
+inline int AMXAPI amx_NumPubVars(AMX* amx, int* number)
 {
 	return ((amx_NumPubVars_t)funcs_[AMX_FUNC_NumPubVars])(amx, number);
 }
 
-int AMXAPI amx_NumTags(AMX* amx, int* number)
+inline int AMXAPI amx_NumTags(AMX* amx, int* number)
 {
 	return ((amx_NumTags_t)funcs_[AMX_FUNC_NumTags])(amx, number);
 }
 
-int AMXAPI amx_Push(AMX* amx, cell value)
+inline int AMXAPI amx_Push(AMX* amx, cell value)
 {
 	return ((amx_Push_t)funcs_[AMX_FUNC_Push])(amx, value);
 }
 
-int AMXAPI amx_PushArray(AMX* amx, cell* amx_addr, cell** phys_addr, const cell array[], int numcells)
+inline int AMXAPI amx_PushArray(AMX* amx, cell* amx_addr, cell** phys_addr, const cell array[], int numcells)
 {
 	return ((amx_PushArray_t)funcs_[AMX_FUNC_PushArray])(amx, amx_addr, phys_addr, array, numcells);
 }
 
-int AMXAPI amx_PushString(AMX* amx, cell* amx_addr, cell** phys_addr, const char* string, int pack, int use_wchar)
+inline int AMXAPI amx_PushString(AMX* amx, cell* amx_addr, cell** phys_addr, const char* string, int pack, int use_wchar)
 {
 	return ((amx_PushString_t)funcs_[AMX_FUNC_PushString])(amx, amx_addr, phys_addr, string, pack, use_wchar);
 }
 
-int AMXAPI amx_PushStringLen(AMX* amx, cell* amx_addr, cell** phys_addr, const char* string, int length, int pack, int use_wchar)
+inline int AMXAPI amx_PushStringLen(AMX* amx, cell* amx_addr, cell** phys_addr, const char* string, int length, int pack, int use_wchar)
 {
 	return ((amx_PushStringLen_t)funcs_[AMX_FUNC_PushStringLen])(amx, amx_addr, phys_addr, string, length, pack, use_wchar);
 }
 
-int AMXAPI amx_RaiseError(AMX* amx, int error)
+inline int AMXAPI amx_RaiseError(AMX* amx, int error)
 {
 	return ((amx_RaiseError_t)funcs_[AMX_FUNC_RaiseError])(amx, error);
 }
 
-int AMXAPI amx_Register(AMX* amx, const AMX_NATIVE_INFO* nativelist, int number)
+inline int AMXAPI amx_Register(AMX* amx, const AMX_NATIVE_INFO* nativelist, int number)
 {
 	return ((amx_Register_t)funcs_[AMX_FUNC_Register])(amx, nativelist, number);
 }
 
-int AMXAPI amx_Release(AMX* amx, cell amx_addr)
+inline int AMXAPI amx_Release(AMX* amx, cell amx_addr)
 {
 	return ((amx_Release_t)funcs_[AMX_FUNC_Release])(amx, amx_addr);
 }
 
-int AMXAPI amx_SetCallback(AMX* amx, AMX_CALLBACK callback)
+inline int AMXAPI amx_SetCallback(AMX* amx, AMX_CALLBACK callback)
 {
 	return ((amx_SetCallback_t)funcs_[AMX_FUNC_SetCallback])(amx, callback);
 }
 
-int AMXAPI amx_SetDebugHook(AMX* amx, AMX_DEBUG debug)
+inline int AMXAPI amx_SetDebugHook(AMX* amx, AMX_DEBUG debug)
 {
 	return ((amx_SetDebugHook_t)funcs_[AMX_FUNC_SetDebugHook])(amx, debug);
 }
 
-int AMXAPI amx_SetString(cell* dest, const char* source, int pack, int use_wchar, size_t size)
+inline int AMXAPI amx_SetString(cell* dest, const char* source, int pack, int use_wchar, size_t size)
 {
 	return ((amx_SetString_t)funcs_[AMX_FUNC_SetString])(dest, source, pack, use_wchar, size);
 }
 
-int AMXAPI amx_SetStringLen(cell* dest, const char* source, int length, int pack, int use_wchar, size_t size)
+inline int AMXAPI amx_SetStringLen(cell* dest, const char* source, int length, int pack, int use_wchar, size_t size)
 {
 	return ((amx_SetStringLen_t)funcs_[AMX_FUNC_SetStringLen])(dest, source, length, pack, use_wchar, size);
 }
 
-int AMXAPI amx_SetUserData(AMX* amx, long tag, void* ptr)
+inline int AMXAPI amx_SetUserData(AMX* amx, long tag, void* ptr)
 {
 	return ((amx_SetUserData_t)funcs_[AMX_FUNC_SetUserData])(amx, tag, ptr);
 }
 
-int AMXAPI amx_StrLen(const cell* cstring, int* length)
+inline int AMXAPI amx_StrLen(const cell* cstring, int* length)
 {
 	return ((amx_StrLen_t)funcs_[AMX_FUNC_StrLen])(cstring, length);
 }
 
-int AMXAPI amx_UTF8Check(const char* string, int* length)
+inline int AMXAPI amx_UTF8Check(const char* string, int* length)
 {
 	return ((amx_UTF8Check_t)funcs_[AMX_FUNC_UTF8Check])(string, length);
 }
 
-int AMXAPI amx_UTF8Get(const char* string, const char** endptr, cell* value)
+inline int AMXAPI amx_UTF8Get(const char* string, const char** endptr, cell* value)
 {
 	return ((amx_UTF8Get_t)funcs_[AMX_FUNC_UTF8Get])(string, endptr, value);
 }
 
-int AMXAPI amx_UTF8Len(const cell* cstr, int* length)
+inline int AMXAPI amx_UTF8Len(const cell* cstr, int* length)
 {
 	return ((amx_UTF8Len_t)funcs_[AMX_FUNC_UTF8Len])(cstr, length);
 }
 
-int AMXAPI amx_UTF8Put(char* string, char** endptr, int maxchars, cell value)
+inline int AMXAPI amx_UTF8Put(char* string, char** endptr, int maxchars, cell value)
 {
 	return ((amx_UTF8Put_t)funcs_[AMX_FUNC_UTF8Put])(string, endptr, maxchars, value);
 }
@@ -446,23 +446,23 @@ void amx_Swap32(uint32_t* v)
 #endif
 
 #if PAWN_CELL_SIZE == 64 && (defined _I64_MAX || defined INT64_MAX || defined HAVE_I64)
-void amx_Swap64(uint64_t* v)
+inline void amx_Swap64(uint64_t* v)
 {
 	return ((amx_Swap64_t)funcs_[AMX_FUNC_Swap64])(v);
 }
 #endif
 
-int AMXAPI amx_GetNativeByIndex(AMX const* amx, int index, AMX_NATIVE_INFO* ret)
+inline int AMXAPI amx_GetNativeByIndex(AMX const* amx, int index, AMX_NATIVE_INFO* ret)
 {
 	return ((amx_GetNativeByIndex_t)funcs_[AMX_FUNC_GetNativeByIndex])(amx, index, ret);
 }
 
-int AMXAPI amx_MakeAddr(AMX* amx, cell* phys_addr, cell* amx_addr)
+inline int AMXAPI amx_MakeAddr(AMX* amx, cell* phys_addr, cell* amx_addr)
 {
 	return ((amx_MakeAddr_t)funcs_[AMX_FUNC_MakeAddr])(amx, phys_addr, amx_addr);
 }
 
-int AMXAPI amx_StrSize(const cell* cstr, int* length)
+inline int AMXAPI amx_StrSize(const cell* cstr, int* length)
 {
 	return ((amx_StrSize_t)funcs_[AMX_FUNC_StrSize])(cstr, length);
 }


### PR DESCRIPTION
fixes for errors such as 
```
natives.obj : error LNK2005: "int __cdecl amx_GetNativeByIndex(struct tagAMX const *,int,struct tagAMX_NATIVE_INFO *)" (?amx_GetNati
veByIndex@@YAHPBUtagAMX@@HPAUtagAMX_NATIVE_INFO@@@Z) already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: "int __cdecl amx_MakeAddr(struct tagAMX *,__int64 *,__int64 *)" (?amx_MakeAddr@@YAHPAUtagAMX@@PA_J1@Z)
already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: "int __cdecl amx_StrSize(__int64 const *,int *)" (?amx_StrSize@@YAHPB_JPAH@Z) already defined in main.o
bj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_Callback already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_Cleanup already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_Clone already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_Exec already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_FindNative already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_FindPubVar already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_FindPublic already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_FindTagId already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_Flags already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_GetAddr already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_GetNative already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_GetPubVar already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_GetPublic already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_GetString already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_GetTag already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_GetUserData already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_Init already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_InitJIT already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_MemInfo already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_NameLength already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_NativeInfo already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_NumNatives already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_NumPubVars already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_NumPublics already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_NumTags already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_Push already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_PushArray already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_PushString already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_PushStringLen already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_RaiseError already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_Register already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_Release already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_SetCallback already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_SetDebugHook already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_SetString already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_SetStringLen already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_SetUserData already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_StrLen already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_Swap64 already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_UTF8Check already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_UTF8Get already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_UTF8Len already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_UTF8Put already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
     Creating library M:/MyJob/open.mp-time/build/RelWithDebInfo/omp-time.lib and object M:/MyJob/open.mp-time/build/RelWithDebInfo/
  omp-time.exp
M:\MyJob\open.mp-time\build\RelWithDebInfo\omp-time.dll : fatal error LNK1169: one or more multiply defined symbols found [M:\MyJob\
open.mp-time\build\omp-time.vcxproj]
```